### PR TITLE
Migrate from Mapbox GL JS to MapLibre GL JS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,9 +20,6 @@ jobs:
 
       - name: Build 🔧
         run: npm run build
-        env:
-          REACT_APP_MAPBOX_ACCESS_TOKEN_ALERT_LOCATION: ${{ secrets.MAPBOX_ACCESS_TOKEN_ALERT_LOCATION }}
-          REACT_APP_MAPBOX_ACCESS_TOKEN_USER_LOCATION: ${{ secrets.MAPBOX_ACCESS_TOKEN_USER_LOCATION }}
 
       # - name: Deploy 🚀
       #   uses: JamesIves/github-pages-deploy-action@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@ant-design/charts": "^1.4.3",
-        "@mapbox/polyline": "^1.2.1",
         "ajv": "^8.17.1",
         "date-fns": "^2.22.1",
         "query-string": "^7.0.1",
@@ -4385,17 +4384,6 @@
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
       "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="
     },
-    "node_modules/@mapbox/polyline": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/polyline/-/polyline-1.2.1.tgz",
-      "integrity": "sha512-sn0V18O3OzW4RCcPoUIVDWvEGQaBNH9a0y5lgqrf5hUycyw1CzrhEoxV5irzrMNXKCkw1xRsZXcaVbsVZggHXA==",
-      "dependencies": {
-        "meow": "^9.0.0"
-      },
-      "bin": {
-        "polyline": "bin/polyline.bin.js"
-      }
-    },
     "node_modules/@mapbox/tiny-sdf": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
@@ -5780,11 +5768,6 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
     },
-    "node_modules/@types/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag=="
-    },
     "node_modules/@types/node": {
       "version": "22.13.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.17.tgz",
@@ -5800,11 +5783,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/normalize-package-data": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
-      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
@@ -6823,14 +6801,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/as-number": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/as-number/-/as-number-1.0.0.tgz",
@@ -7571,30 +7541,6 @@
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/camelcase-keys": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-      "dependencies": {
-        "camelcase": "^5.3.1",
-        "map-obj": "^4.0.0",
-        "quick-lru": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/camelcase-keys/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/caniuse-api": {
@@ -8766,29 +8712,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decamelize-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
-      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
-      "dependencies": {
-        "decamelize": "^1.1.0",
-        "map-obj": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/decamelize-keys/node_modules/map-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11524,14 +11447,6 @@
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg=="
     },
-    "node_modules/hard-rejection": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
-      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/harmony-reflect": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
@@ -11651,17 +11566,6 @@
       "integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==",
       "engines": {
         "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/hosted-git-info": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/hpack.js": {
@@ -12078,6 +11982,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -12452,14 +12357,6 @@
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-plain-object": {
@@ -14994,17 +14891,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -15063,17 +14949,6 @@
       "integrity": "sha512-Sv5r0/PrQRq4pW+9lDicGsEPzPLkd1PwjTs5zHUV1I293S3alkBNyuSjktVeBploofH8MAMLd4DS2crwct48wg==",
       "dependencies": {
         "inversify": "^5.0.1"
-      }
-    },
-    "node_modules/map-obj": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
-      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mapbox-gl": {
@@ -15212,31 +15087,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/meow": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
-      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
-      "dependencies": {
-        "@types/minimist": "^1.2.0",
-        "camelcase-keys": "^6.2.2",
-        "decamelize": "^1.2.0",
-        "decamelize-keys": "^1.1.0",
-        "hard-rejection": "^2.1.0",
-        "minimist-options": "4.1.0",
-        "normalize-package-data": "^3.0.0",
-        "read-pkg-up": "^7.0.1",
-        "redent": "^3.0.0",
-        "trim-newlines": "^3.0.0",
-        "type-fest": "^0.18.0",
-        "yargs-parser": "^20.2.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
@@ -15320,6 +15170,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -15365,27 +15216,6 @@
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/minimist-options": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
-      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-      "dependencies": {
-        "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0",
-        "kind-of": "^6.0.3"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/minimist-options/node_modules/kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/minipass": {
@@ -15608,20 +15438,6 @@
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="
-    },
-    "node_modules/normalize-package-data": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-      "dependencies": {
-        "hosted-git-info": "^4.0.1",
-        "is-core-module": "^2.5.0",
-        "semver": "^7.3.4",
-        "validate-npm-package-license": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -17768,14 +17584,6 @@
         }
       ]
     },
-    "node_modules/quick-lru": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/quickselect": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
@@ -19365,76 +19173,6 @@
         "pify": "^2.3.0"
       }
     },
-    "node_modules/read-pkg": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-      "dependencies": {
-        "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
-        "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-      "dependencies": {
-        "find-up": "^4.1.0",
-        "read-pkg": "^5.2.0",
-        "type-fest": "^0.8.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg/node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
-    },
-    "node_modules/read-pkg/node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/read-pkg/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
-    "node_modules/read-pkg/node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -19474,6 +19212,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
       "dependencies": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
@@ -20754,34 +20493,6 @@
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "deprecated": "Please use @jridgewell/sourcemap-codec instead"
     },
-    "node_modules/spdx-correct": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
-      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-exceptions": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
-      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w=="
-    },
-    "node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/spdx-license-ids": {
-      "version": "3.0.21",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.21.tgz",
-      "integrity": "sha512-Bvg/8F5XephndSK3JffaRqdT+gyhfqIPwDHpX80tJrF8QQRYMo8sNMeaZ2Dp5+jhwKnUmIOyFFQfHRkjJm5nXg=="
-    },
     "node_modules/spdy": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
@@ -21248,6 +20959,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
       "dependencies": {
         "min-indent": "^1.0.0"
       },
@@ -21871,14 +21583,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/trim-newlines": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
-      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/trim-repeated": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
@@ -21969,17 +21673,6 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -22390,15 +22083,6 @@
       "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
       }
     },
     "node_modules/vary": {
@@ -23339,11 +23023,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   ],
   "dependencies": {
     "@ant-design/charts": "^1.4.3",
-    "@mapbox/polyline": "^1.2.1",
     "ajv": "^8.17.1",
     "date-fns": "^2.22.1",
     "query-string": "^7.0.1",

--- a/public/index.html
+++ b/public/index.html
@@ -57,11 +57,11 @@
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"
     />
     <link
-      href="https://api.mapbox.com/mapbox-gl-js/v2.14.1/mapbox-gl.css"
+      href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css"
       rel="stylesheet"
     />
     <link rel="me" href="https://mastodon.social/@rocketalert" />
-    <script src="https://api.mapbox.com/mapbox-gl-js/v2.14.1/mapbox-gl.js"></script>
+    <script src="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.js"></script>
     <script
       async
       src="https://www.googletagmanager.com/gtag/js?id=G-1N212TJJCK"

--- a/public/index.html
+++ b/public/index.html
@@ -53,10 +53,6 @@
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"
     />
     <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,0,0"
-    />
-    <link
       href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css"
       rel="stylesheet"
     />

--- a/src/components/RecentAlertsInteractiveMap.js
+++ b/src/components/RecentAlertsInteractiveMap.js
@@ -28,7 +28,12 @@ class RecentAlertsInteractiveMap extends React.Component {
       style: MAP_STYLE,
       center: [this.props.alerts[0].lon, this.props.alerts[0].lat],
       cooperativeGestures: true,
-    });
+      attributionControl: false,
+    }).addControl(
+      new window.maplibregl.AttributionControl({
+        compact: true,
+      }),
+    );
 
     map.on("load", () => {
       this.initMap(map);

--- a/src/components/RecentAlertsInteractiveMap.js
+++ b/src/components/RecentAlertsInteractiveMap.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import MAP_STYLE from "../mapStyle";
 
 class RecentAlertsInteractiveMap extends React.Component {
   state = {
@@ -22,12 +23,9 @@ class RecentAlertsInteractiveMap extends React.Component {
   }
 
   async initMapWithAlertLocation() {
-    window.mapboxgl.accessToken =
-      process.env.REACT_APP_MAP_ALERT_LOCATION_TOKEN;
-
-    const map = new window.mapboxgl.Map({
+    const map = new window.maplibregl.Map({
       container: "alerts_map",
-      style: "mapbox://styles/mapbox/dark-v11",
+      style: MAP_STYLE,
       center: [this.props.alerts[0].lon, this.props.alerts[0].lat],
       cooperativeGestures: true,
     });
@@ -39,7 +37,7 @@ class RecentAlertsInteractiveMap extends React.Component {
 
   drawMapMarkersAndPolygons = (map, geojson) => {
     const alertNames = [];
-    const bounds = new window.mapboxgl.LngLatBounds();
+    const bounds = new window.maplibregl.LngLatBounds();
 
     this.props.alerts.forEach((alert) => {
       if (alertNames.includes(alert.name)) {
@@ -69,7 +67,7 @@ class RecentAlertsInteractiveMap extends React.Component {
       // Add a marker
       const el = document.createElement("div");
       el.className = "map-marker";
-      new window.mapboxgl.Marker(el)
+      new window.maplibregl.Marker(el)
         .setLngLat([alert.lon, alert.lat])
         .addTo(map);
     });

--- a/src/components/RecentAlertsInteractiveMap.js
+++ b/src/components/RecentAlertsInteractiveMap.js
@@ -67,7 +67,7 @@ class RecentAlertsInteractiveMap extends React.Component {
       // Add a marker
       const el = document.createElement("div");
       el.className = "map-marker";
-      new window.maplibregl.Marker(el)
+      new window.maplibregl.Marker({ element: el })
         .setLngLat([alert.lon, alert.lat])
         .addTo(map);
     });

--- a/src/components/RecentAlertsMap.js
+++ b/src/components/RecentAlertsMap.js
@@ -4,12 +4,14 @@ import Cache from "../cache";
 import Tracking from "../tracking";
 import Utilities from "../utilities/utilities";
 import RecentAlertsInteractiveMap from "./RecentAlertsInteractiveMap";
+// import RecentAlertsStaticMap from "./RecentAlertsStaticMap";
 import withIsVisibleHook from "./withIsVisibleHook";
 
 const RecentAlertsMap = ({ alerts, mapFocus, isIntersectingRef }) => {
   const [polygons, setPolygons] = useState({});
   const shouldShowInteractiveMap =
     process.env.REACT_APP_IS_MAP_INTERACTIVE === "true";
+  // const shouldShowStaticMap = process.env.REACT_APP_IS_MAP_STATIC === "true";
 
   const loadPolygons = () => {
     if (Cache.canUseCache()) {
@@ -69,6 +71,9 @@ const RecentAlertsMap = ({ alerts, mapFocus, isIntersectingRef }) => {
           mapFocus={mapFocus}
         />
       )}
+      {/* {shouldShowStaticMap && (
+        <RecentAlertsStaticMap alerts={alerts} polygons={polygons} />
+      )} */}
     </section>
   );
 };

--- a/src/components/RecentAlertsMap.js
+++ b/src/components/RecentAlertsMap.js
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 import Cache from "../cache";
 import Tracking from "../tracking";
 import Utilities from "../utilities/utilities";
-import RecentAlertsStaticMap from "./RecentAlertsStaticMap";
 import RecentAlertsInteractiveMap from "./RecentAlertsInteractiveMap";
 import withIsVisibleHook from "./withIsVisibleHook";
 
@@ -11,7 +10,6 @@ const RecentAlertsMap = ({ alerts, mapFocus, isIntersectingRef }) => {
   const [polygons, setPolygons] = useState({});
   const shouldShowInteractiveMap =
     process.env.REACT_APP_IS_MAP_INTERACTIVE === "true";
-  const shouldShowStaticMap = process.env.REACT_APP_IS_MAP_STATIC === "true";
 
   const loadPolygons = () => {
     if (Cache.canUseCache()) {
@@ -70,9 +68,6 @@ const RecentAlertsMap = ({ alerts, mapFocus, isIntersectingRef }) => {
           polygons={polygons}
           mapFocus={mapFocus}
         />
-      )}
-      {shouldShowStaticMap && (
-        <RecentAlertsStaticMap alerts={alerts} polygons={polygons} />
       )}
     </section>
   );

--- a/src/components/UserLocationMap.js
+++ b/src/components/UserLocationMap.js
@@ -59,7 +59,7 @@ const UserLocationMap = ({ alerts }) => {
           // Add a marker
           const el = document.createElement("div");
           el.className = "map-marker";
-          new window.maplibregl.Marker(el)
+          new window.maplibregl.Marker({ element: el })
             .setLngLat([pos.lon, pos.lat])
             .addTo(map);
 

--- a/src/components/UserLocationMap.js
+++ b/src/components/UserLocationMap.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from "react";
 import Tracking from "../tracking";
 import Utilities from "../utilities/utilities";
+import MAP_STYLE from "../mapStyle";
 
 const UserLocationMap = ({ alerts }) => {
   const [showMap, setShowMap] = useState(false);
@@ -35,7 +36,6 @@ const UserLocationMap = ({ alerts }) => {
 
     navigator.geolocation.getCurrentPosition(
       (position) => {
-        // This needs to be first for Mapbox to render properly
         setShowMap(true);
         const pos = {
           lat: position.coords.latitude,
@@ -45,11 +45,9 @@ const UserLocationMap = ({ alerts }) => {
           alert.countdownSec
         );
 
-        window.mapboxgl.accessToken =
-          process.env.REACT_APP_MAP_USER_LOCATION_TOKEN;
-        const map = new window.mapboxgl.Map({
+        const map = new window.maplibregl.Map({
           container: "user_location_map",
-          style: "mapbox://styles/mapbox/dark-v11",
+          style: MAP_STYLE,
           center: [pos.lon, pos.lat],
           zoom: getMapZoomByDistance(alertDistance),
           cooperativeGestures: true,
@@ -61,7 +59,7 @@ const UserLocationMap = ({ alerts }) => {
           // Add a marker
           const el = document.createElement("div");
           el.className = "map-marker";
-          new window.mapboxgl.Marker(el)
+          new window.maplibregl.Marker(el)
             .setLngLat([pos.lon, pos.lat])
             .addTo(map);
 

--- a/src/mapStyle.js
+++ b/src/mapStyle.js
@@ -1,0 +1,26 @@
+const MAP_STYLE = {
+  version: 8,
+  sources: {
+    "carto-dark": {
+      type: "raster",
+      tiles: [
+        "https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}@2x.png",
+        "https://b.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}@2x.png",
+        "https://c.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}@2x.png",
+      ],
+      tileSize: 256,
+      attribution:
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+    },
+  },
+  layers: [
+    {
+      id: "carto-dark-layer",
+      type: "raster",
+      source: "carto-dark",
+      minzoom: 0,
+      maxzoom: 19,
+    },
+  ],
+};
+export default MAP_STYLE;

--- a/src/mapStyle.js
+++ b/src/mapStyle.js
@@ -20,6 +20,9 @@ const MAP_STYLE = {
       source: "carto-dark",
       minzoom: 0,
       maxzoom: 19,
+      paint: {
+        "raster-brightness-min": 0.08,
+      },
     },
   ],
 };

--- a/src/mapStyle.js
+++ b/src/mapStyle.js
@@ -10,7 +10,7 @@ const MAP_STYLE = {
       ],
       tileSize: 256,
       attribution:
-        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>',
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OSM</a>',
     },
   },
   layers: [


### PR DESCRIPTION
## Summary

- Replace paid Mapbox GL JS with free, open-source MapLibre GL JS and CARTO dark raster tiles
- Remove Mapbox access tokens, static map component usage, and @mapbox/polyline dependency
- Remove Mapbox token env vars from CI workflow
- Fix marker rendering to use MapLibre's { element } option syntax

## Changes

- public/index.html - Replaced Mapbox CDN with MapLibre GL JS v4.7.1
- src/mapStyle.js (new) - Shared CARTO dark raster tile style
- src/components/RecentAlertsInteractiveMap.js - mapboxgl → maplibregl, removed token, replaced style
- src/components/UserLocationMap.js - Same as above
- src/components/RecentAlertsMap.js - Removed static map import and conditional
- package.json - Removed @mapbox/polyline dependency
- .github/workflows/main.yml - Removed Mapbox token env vars

## Test plan

- [x] Interactive map loads with dark tiles
- [x] Polygons render (red filled areas) for active alerts
- [x] Red markers appear at alert locations
- [x] `fitBounds` auto-zooms to show all alerts
- [x] Clicking an alert in the list pans the map
- [x] Cooperative gestures work
- [x] `npm test` passes (24/24)
- [x] `npm run build` succeeds without Mapbox tokens