### PR TITLE
Fix: header metric Sentry errors

### DIFF
--- a/src/components/Header/HeaderContainer.js
+++ b/src/components/Header/HeaderContainer.js
@@ -84,9 +84,11 @@ const HeaderContainer = (props) => {
           setIsLoading(false);
         }
         const perfTime = performance.now() - props.perfStartTime;
-        Sentry.metrics.distribution("header", perfTime, {
-          unit: "millisecond",
-        });
+        if (perfTime && !Number.isNaN(perfTime)) {
+          Sentry.metrics.distribution("header", perfTime, {
+            unit: "millisecond",
+          });
+        }
       })
       .catch((error) => {
         Tracking.headerDataError(error);


### PR DESCRIPTION
Guard Sentry metric distribution call in HeaderContainer to prevent NaN values from props.perfStartTime