### PR TITLE
Fix: prevent WebGL context issues and stack overflow on iOS

### DIFF
--- a/src/components/RecentAlertsInteractiveMap.js
+++ b/src/components/RecentAlertsInteractiveMap.js
@@ -29,6 +29,12 @@ class RecentAlertsInteractiveMap extends React.Component {
     }
   }
 
+  componentWillUnmount() {
+    if (this.state.map) {
+      this.state.map.remove();
+    }
+  }
+
   getCenterMap = (mostRecentAlerts, alerts48HrsAgo) => {
     const DEFAULT_CENTER = [31.7683, 35.2433]; // Jerusalem
     if (!mostRecentAlerts || !alerts48HrsAgo) {
@@ -213,11 +219,12 @@ class RecentAlertsInteractiveMap extends React.Component {
     this.addLineLayer(map, "p-l-48hrs-uavs", geojson48HrsUAVs, "#a87548");
 
     const overallBounds = bounds1.extend(bounds2);
-    map.fitBounds(overallBounds, {
-      padding: this.MAP_PADDING,
-      animate: false,
-    });
-
+    if (!overallBounds.isEmpty()) {
+      map.fitBounds(overallBounds, {
+        padding: this.MAP_PADDING,
+        animate: false,
+      });
+    }
     this.setState({ map, mapBounds: overallBounds });
   };
 
@@ -263,12 +270,12 @@ class RecentAlertsInteractiveMap extends React.Component {
     // const overallBounds = bounds1.extend(bounds2);
 
     const newBounds = this.state.mapBounds.extend(bounds);
-
-    map.fitBounds(newBounds, {
-      padding: this.MAP_PADDING,
-      animate: true,
-    });
-
+    if (!newBounds.isEmpty()) {
+      map.fitBounds(newBounds, {
+        padding: this.MAP_PADDING,
+        animate: true,
+      });
+    }
     this.setState({ map, mapBounds: newBounds });
   };
 


### PR DESCRIPTION
Add componentWillUnmount for map cleanup and validate bounds before fitBounds to prevent WebGL context issues and stack overflow on iOS.

Fix: Mapbox GL JS map cleanup and fitBounds robustness
- Added componentWillUnmount to remove the Mapbox GL JS map instance, preventing potential memory leaks.
- Wrapped map.fitBounds calls in initMapWithAlertLocation and addAlertToMap with checks for empty bounds to prevent errors when no alerts are present.