### PR TITLE
fix: use node v22.12 in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.12.0
 
       - name: Install
         run: npm ci
@@ -48,7 +48,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20.10.0
+          node-version: 22.12.0
 
       - run: npm ci
 


### PR DESCRIPTION
Vite migration: addition to CI changes in https://github.com/ErezNagar/rocket-alert/pull/78