### PR TITLE
feat: deprecate /details endpoint in favor of past48Hours

### DIFF
--- a/src/rocket_alert_client.ts
+++ b/src/rocket_alert_client.ts
@@ -23,46 +23,15 @@ const filterRocketAndUAVAlerts = (res: any) => {
   return res;
 };
 
-/*
- *  Gets detailed alert data for alerts in the given date range
- *
- *  @param {string} from  from date, inclusive.
- *  @param {string} to    to date, inclusive.
- *  @return {object}
- */
-const getDetailedAlerts = (
-  from: string,
-  to: string,
-  alertTypeId: number = Utilities.ALERT_TYPE_ALL,
-) => {
-  if (!from || !isValid(new Date(from))) {
-    return Promise.reject(new Error("Invalid Date: from"));
-  }
-  if (!to || !isValid(new Date(to))) {
-    return Promise.reject(new Error("Invalid Date: to"));
-  }
-  return APIv1.url("/details")
-    .query({
-      from: isoFormat(convertToServerTime(from)),
-      to: isoFormat(convertToServerTime(to)),
-      alertTypeId,
-    })
-    .get()
-    .json()
-    .then((res) => filterRocketAndUAVAlerts(res));
-};
-
 const AlertClient = {
-  getDetailedAlerts,
   /*
-   *  Gets the MAX_RECENT_ALERTS most recent alerts in the past 24 hours.
-   *
-   *  @param {string} from  from date, inclusive.
-   *  @param {string} to    to date, inclusive.
-   *  @return {object}
+   *  Gets full alert data for all alerts in the past 48 hours.
    */
-  getMostRecentAlerts: (from: string, to: string): any =>
-    getDetailedAlerts(from, to)
+  getMostRecentAlerts: (): any =>
+    APIv1.url("/past48h")
+      .get()
+      .json()
+      .then(filterRocketAndUAVAlerts)
       .then((res) => {
         if (!res.success) {
           return null;

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,7 @@ import svgr from "vite-plugin-svgr";
 
 export default defineConfig({
   plugins: [react(), svgr()],
-  base: process.env.PUBLIC_URL || "/", // IMPORTANT for GitHub Pages + PR previews "homepage": "https://ereznagar.github.io",
+  base: process.env.PUBLIC_URL || "/", // IMPORTANT for GitHub Pages + PR previews
   test: {
     environment: "jsdom",
     globals: true,


### PR DESCRIPTION
Deprecating `/details` endpoint in favor of the more cacheable and newly created `past48Hours` one.